### PR TITLE
Update nfs-ganesha-callout

### DIFF
--- a/nfs-ganesha-callout
+++ b/nfs-ganesha-callout
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This CTDB NFS callout script for Ganesha is based on the example
 # nfs-ganesha-callout shipped with CTDB.


### PR DESCRIPTION
I need to put bash instead of sh on Debian Stretch. I don't know if it breaks on other systems.