### PR TITLE
Copy secret.pem 

### DIFF
--- a/storhaug
+++ b/storhaug
@@ -171,6 +171,15 @@ setup_copy_ctdb_config()
     done
 }
 
+setup_copy_secret_pem()
+{
+    for srv in ${HA_SERVERS[*]}; do
+        if [[ ${srv} != ${MY_IPS[0]} ]]; then
+            scp_do ${SECRET_PEM} "${srv}:${SECRET_PEM}"
+        fi
+    done
+}
+
 setup_start_ctdb()
 {
     for srv in ${HA_SERVERS[*]}; do
@@ -302,6 +311,7 @@ case "${cmd}" in
             if [ ${HA_NUM_SERVERS} -gt 1 ]; then
                 setup_move_ganesha_config
                 setup_copy_ctdb_config
+                setup_copy_secret_pem
                 setup_start_ctdb
             else
                 storlog "ERR" "Insufficient servers for HA, aborting"


### PR DESCRIPTION
Copy secret.pem to other servers to make `nfs_releaseip()` and `nfs_takeip()` from `nfs-ganesha-callout` working correctly.

Whitout this, I got Warnings in ctdb log file.
`Warning: Identity file /etc/default/storhaug.d/secret.pem not accessible: No such file or directory.`
`WARNING: Command failed on 192.168.22.22: dbus-send --print-reply --system --dest=org.ganesha.nfsd`