### PR TITLE
Get linux distro to adjust secret_pem path

### DIFF
--- a/storhaug
+++ b/storhaug
@@ -15,6 +15,10 @@ HA_NUM_SERVERS=0
 declare -a HA_SERVERS
 
 SECRET_PEM="/etc/sysconfig/storhaug.d/secret.pem"
+eval DISTRO=( $(lsb_release -i | cut -f 2) )
+if [[ $DISTRO == "Debian" || $DISTRO == "Ubuntu" ]]; then
+	SECRET_PEM="/etc/default/storhaug.d/secret.pem"
+fi
 
 MY_IPS=( $(hostname -I || hostname -i) )
 


### PR DESCRIPTION
If lsb_release is on centOS, Redhat and other distro, it will do the job but IMO the `secret.pem` should be place in `/etc/storhaug/secret.pem` . Than the SECRET_PEM path will be valid for all distribution.