### PR TITLE
nfs-ganesha-callout: do not fail if /proc/sys/net/ipv4/tcp_tw_recycle doesn't exist

### DIFF
--- a/nfs-ganesha-callout
+++ b/nfs-ganesha-callout
@@ -283,7 +283,7 @@ nfs_startup ()
 
 	basic_start "nfs"
 	_f="${procfs}/sys/net/ipv4/tcp_tw_recycle"
-	if [ "$_f" ] ; then
+	if [ -f "$_f" ] ; then
 		echo 1 >"$_f"
 	fi
 }


### PR DESCRIPTION
In the nfs_startup function the variable tcp_tw_recycle is set to 1,
but in some versions of linux that variable is not present.

I think that that variable has been removed from the kernel, I had problems with linux 4.15.0-30-generic from ubuntu 18.04